### PR TITLE
Update causality crate for Rust 2018

### DIFF
--- a/src/causality/Cargo.toml
+++ b/src/causality/Cargo.toml
@@ -3,6 +3,7 @@ name = "causality"
 version = "0.1.0"
 authors = []
 publish = false
+edition = "2018"
 
 [dependencies]
 itc = "0.1.2"


### PR DESCRIPTION
#64 Update causality crate for Rust 2018 by adding edition='2018' to Cargo.toml