### PR TITLE
Packet encryption and checksum

### DIFF
--- a/src/crypto/src/lib.rs
+++ b/src/crypto/src/lib.rs
@@ -19,6 +19,7 @@
 #[macro_use]
 extern crate serde_derive;
 
+pub extern crate crc32fast;
 extern crate blake2_rfc;
 extern crate hashdb;
 extern crate hex;
@@ -27,7 +28,6 @@ extern crate quickcheck;
 extern crate rand;
 extern crate rlp;
 extern crate byteorder;
-extern crate crc32fast;
 extern crate rust_base58;
 extern crate rust_sodium;
 

--- a/src/crypto/src/lib.rs
+++ b/src/crypto/src/lib.rs
@@ -62,7 +62,7 @@ pub fn verify(message: &[u8], signature: &Signature, pkey: &PublicKey) -> bool {
     verify_detached(&signature.inner(), message, pkey)
 }
 
-pub fn seal(message: &[u8], key: &KxPublicKey) -> (Vec<u8>, Nonce) {
+pub fn seal(message: &[u8], key: &SessionKey) -> (Vec<u8>, Nonce) {
     let n = aead::gen_nonce();
     let key = aead::Key::from_slice(&key.0).unwrap();
     let ciphertext = aead::seal(message, None, &n, &key);
@@ -70,7 +70,7 @@ pub fn seal(message: &[u8], key: &KxPublicKey) -> (Vec<u8>, Nonce) {
     (ciphertext, n)
 }
 
-pub fn open(ciphertext: &[u8], key: &KxPublicKey, nonce: &Nonce) -> Result<Vec<u8>, ()> {
+pub fn open(ciphertext: &[u8], key: &SessionKey, nonce: &Nonce) -> Result<Vec<u8>, ()> {
     let key = aead::Key::from_slice(&key.0).unwrap();
     
     match aead::open(ciphertext, None, nonce, &key) {

--- a/src/network/src/common.rs
+++ b/src/network/src/common.rs
@@ -1,0 +1,134 @@
+/*
+  Copyright 2018 The Purple Library Authors
+  This file is part of the Purple Library.
+
+  The Purple Library is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Purple Library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with the Purple Library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use crate::error::NetworkErr;
+use crypto::{Nonce, KxPublicKey};
+use crypto::crc32fast::Hasher;
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::io::Cursor;
+
+pub const NETWORK_VERSION: u8 = 0;
+
+/// Encrypts and wraps a packet with the default network header
+/// 
+/// ### Header fields
+/// 1) Network layer version   - 8bits
+/// 2) Packet length           - 32bits
+/// 3) CRC32 of packet + nonce - 32bits
+/// 4) Nonce                   - 12bytes
+/// 5) Packet                  - Binary of packet length
+pub fn wrap_packet(packet: &[u8], key: &KxPublicKey) -> Vec<u8> {
+    let (encrypted, nonce) = crypto::seal(packet, key);
+    let packet_len = encrypted.len();
+    let mut buf: Vec<u8> = Vec::with_capacity(21 + packet_len);
+    let mut crc32 = Hasher::new();
+
+    crc32.update(&encrypted);
+    crc32.update(&nonce.0);
+
+    let crc32 = crc32.finalize();
+
+    buf.write_u8(NETWORK_VERSION).unwrap();
+    buf.write_u32::<BigEndian>(packet_len as u32).unwrap();
+    buf.write_u32::<BigEndian>(crc32).unwrap();
+    buf.extend_from_slice(&nonce.0);
+    buf.extend_from_slice(&encrypted);
+    buf
+}
+
+
+/// Attempts to decrypt a packet
+pub fn unwrap_packet(packet: &[u8], key: &KxPublicKey) -> Result<Vec<u8>, NetworkErr> {
+    let mut rdr = Cursor::new(packet.to_vec());
+    let version = if let Ok(result) = rdr.read_u8() {
+        result
+    } else {
+        return Err(NetworkErr::BadFormat);
+    };
+
+    if version != NETWORK_VERSION {
+        return Err(NetworkErr::BadVersion);
+    }
+
+    rdr.set_position(1);
+
+    let packet_len = if let Ok(result) = rdr.read_u32::<BigEndian>() {
+        result
+    } else {
+        return Err(NetworkErr::BadFormat);
+    };
+
+    rdr.set_position(5);
+
+    let packet_crc32 = if let Ok(result) = rdr.read_u32::<BigEndian>() {
+        result
+    } else {
+        return Err(NetworkErr::BadFormat);
+    };
+
+    let mut buf: Vec<u8> = rdr.into_inner();
+    let _: Vec<u8> = buf.drain(..9).collect();
+
+    let nonce = if buf.len() > 12 as usize {
+        let mut nonce = [0; 12];
+        let nonce_vec: Vec<u8> = buf.drain(..12).collect();
+
+        nonce.copy_from_slice(&nonce_vec);
+
+        Nonce(nonce)
+    } else {
+        return Err(NetworkErr::BadFormat);
+    };
+
+    let packet = if buf.len() == packet_len as usize {
+        buf
+    } else {
+        return Err(NetworkErr::BadFormat);
+    };
+
+    let mut crc32 = Hasher::new();
+
+    crc32.update(&packet);
+    crc32.update(&nonce.0);
+
+    let crc32 = crc32.finalize();
+
+    // Check CRC32 checksum
+    if crc32 != packet_crc32 {
+        return Err(NetworkErr::BadCRC32);
+    }
+
+    match crypto::open(&packet, key, &nonce) {
+        Ok(result) => Ok(result),
+        Err(_) => Err(NetworkErr::EncryptionErr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    quickcheck! {
+        fn wrap_unwrap(packet: Vec<u8>) -> bool {
+            let key = KxPublicKey([0; 32]);
+
+            assert_eq!(packet, unwrap_packet(&wrap_packet(&packet, &key), &key).unwrap());
+            true
+        }
+    }
+}

--- a/src/network/src/common.rs
+++ b/src/network/src/common.rs
@@ -17,7 +17,7 @@
 */
 
 use crate::error::NetworkErr;
-use crypto::{Nonce, KxPublicKey};
+use crypto::{Nonce, SessionKey};
 use crypto::crc32fast::Hasher;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::io::Cursor;
@@ -32,7 +32,7 @@ pub const NETWORK_VERSION: u8 = 0;
 /// 3) CRC32 of packet + nonce - 32bits
 /// 4) Nonce                   - 12bytes
 /// 5) Packet                  - Binary of packet length
-pub fn wrap_packet(packet: &[u8], key: &KxPublicKey) -> Vec<u8> {
+pub fn wrap_packet(packet: &[u8], key: &SessionKey) -> Vec<u8> {
     let (encrypted, nonce) = crypto::seal(packet, key);
     let packet_len = encrypted.len();
     let mut buf: Vec<u8> = Vec::with_capacity(21 + packet_len);
@@ -53,7 +53,7 @@ pub fn wrap_packet(packet: &[u8], key: &KxPublicKey) -> Vec<u8> {
 
 
 /// Attempts to decrypt a packet
-pub fn unwrap_packet(packet: &[u8], key: &KxPublicKey) -> Result<Vec<u8>, NetworkErr> {
+pub fn unwrap_packet(packet: &[u8], key: &SessionKey) -> Result<Vec<u8>, NetworkErr> {
     let mut rdr = Cursor::new(packet.to_vec());
     let version = if let Ok(result) = rdr.read_u8() {
         result
@@ -125,7 +125,7 @@ mod tests {
 
     quickcheck! {
         fn wrap_unwrap(packet: Vec<u8>) -> bool {
-            let key = KxPublicKey([0; 32]);
+            let key = SessionKey([0; 32]);
 
             assert_eq!(packet, unwrap_packet(&wrap_packet(&packet, &key), &key).unwrap());
             true

--- a/src/network/src/error.rs
+++ b/src/network/src/error.rs
@@ -21,6 +21,9 @@ pub enum NetworkErr {
     /// The format of the packet is invalid
     BadFormat,
 
+    /// The packet has an invalid signature
+    BadSignature,
+
     /// The connection attempt has failed
     ConnectFailed,
 

--- a/src/network/src/error.rs
+++ b/src/network/src/error.rs
@@ -45,4 +45,13 @@ pub enum NetworkErr {
 
     /// We have received more peers than we have requested
     TooManyPeers,
+
+    /// The encryption was not valid
+    EncryptionErr,
+
+    /// The CRC32 checksum was invalid
+    BadCRC32,
+
+    /// The network version found in the packet is invalid
+    BadVersion,
 }

--- a/src/network/src/interface.rs
+++ b/src/network/src/interface.rs
@@ -40,7 +40,7 @@ pub trait NetworkInterface {
     fn disconnect_from_ip(&mut self, ip: &SocketAddr) -> Result<(), NetworkErr>;
 
     /// Sends a packet to a specific peer.
-    fn send_to_peer(&self, peer: &NodeId, packet: &[u8]) -> Result<(), NetworkErr>;
+    fn send_to_peer(&self, peer: &SocketAddr, packet: &[u8]) -> Result<(), NetworkErr>;
 
     /// Sends a packet to all peers.
     fn send_to_all(&self, packet: &[u8]) -> Result<(), NetworkErr>;
@@ -48,7 +48,14 @@ pub trait NetworkInterface {
     /// Attempts to send a packet to the specific peer. This
     /// function will also sign the packet if it does not yet
     /// have a signature and it will also serialize it to binary.
-    fn send_unsigned<P: Packet>(&self, peer: &NodeId, packet: &mut P) -> Result<(), NetworkErr>;
+    fn send_unsigned<P: Packet>(&self, peer: &SocketAddr, packet: &mut P) -> Result<(), NetworkErr>;
+
+    /// Sends a raw packet to a specific peer. This 
+    /// means that the packet will be un-encrypted.
+    fn send_raw(&self, peer: &SocketAddr, packet: &[u8]) -> Result<(), NetworkErr>;
+
+    /// This behaves similarly to `send_unsigned()` but it sends a raw packet.
+    fn send_raw_unsigned<P: Packet>(&self, peer: &SocketAddr, packet: &mut P) -> Result<(), NetworkErr>;
 
     /// Callback that processes each packet that is received from any peer.
     fn process_packet(&mut self, peer: &SocketAddr, packet: &[u8]) -> Result<(), NetworkErr>;

--- a/src/network/src/lib.rs
+++ b/src/network/src/lib.rs
@@ -51,6 +51,7 @@ mod node_id;
 pub mod packets;
 mod peer;
 mod packet;
+mod common;
 
 pub use packet::*;
 pub use bootstrap::*;

--- a/src/network/src/network.rs
+++ b/src/network/src/network.rs
@@ -123,7 +123,7 @@ impl NetworkInterface for Network {
         unimplemented!();
     }
 
-    fn send_to_peer(&self, peer: &NodeId, packet: &[u8]) -> Result<(), NetworkErr> {
+    fn send_to_peer(&self, peer: &SocketAddr, packet: &[u8]) -> Result<(), NetworkErr> {
         unimplemented!();
     }
 
@@ -131,13 +131,28 @@ impl NetworkInterface for Network {
         unimplemented!();
     }
 
-    fn send_unsigned<P: Packet>(&self, peer: &NodeId, packet: &mut P) -> Result<(), NetworkErr> {
+    fn send_raw(&self, peer: &SocketAddr, packet: &[u8]) -> Result<(), NetworkErr> {
+        unimplemented!();
+    }
+
+    fn send_unsigned<P: Packet>(&self, peer: &SocketAddr, packet: &mut P) -> Result<(), NetworkErr> {
         if packet.signature().is_none() {
             packet.sign(&self.secret_key);
         }
 
         let packet = packet.to_bytes();
         self.send_to_peer(peer, &packet)?;
+
+        Ok(())
+    }
+
+    fn send_raw_unsigned<P: Packet>(&self, peer: &SocketAddr, packet: &mut P) -> Result<(), NetworkErr> {
+        if packet.signature().is_none() {
+            packet.sign(&self.secret_key);
+        }
+
+        let packet = packet.to_bytes();
+        self.send_raw(peer, &packet)?;
 
         Ok(())
     }

--- a/src/network/src/packets/send_peers.rs
+++ b/src/network/src/packets/send_peers.rs
@@ -240,6 +240,10 @@ impl Packet for SendPeers {
     }
 
     fn handle<N: NetworkInterface>(network: &mut N, addr: &SocketAddr, packet: &SendPeers, conn_type: ConnectionType) -> Result<(), NetworkErr> {
+        if !packet.verify_sig() {
+            return Err(NetworkErr::BadSignature);
+        }
+        
         debug!("Received SendPeers packet from: {:?}", addr);
 
         {
@@ -450,7 +454,7 @@ mod tests {
             };
 
             let mut packet = RequestPeers::new(node_id, 3);
-            network.send_unsigned::<RequestPeers>(&peer_id, &mut packet).unwrap();
+            network.send_unsigned::<RequestPeers>(&addr1, &mut packet).unwrap();
         }
 
         // Pause main thread for a bit before


### PR DESCRIPTION
Closes #52 

### Changes
* Added packet header.
* All packets except `Connect` are now being encrypted.
* Added unintentional packet corruption check using CRC32 checksum.