### PR TITLE
Peer connection protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,7 @@ name = "network"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain 0.1.0",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto 0.1.0",
  "merkle_light 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mimalloc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mimalloc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia-trie 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "persistence 0.1.0",
@@ -1031,7 +1031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1438,7 +1438,7 @@ dependencies = [
  "hashdb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mimalloc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mimalloc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia-trie 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1487,7 +1487,7 @@ dependencies = [
  "jsonrpc-macros 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jump 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mimalloc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mimalloc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "miner 0.1.0",
  "network 0.1.0",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1597,7 +1597,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1626,7 +1626,7 @@ name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1674,7 +1674,7 @@ name = "rand_xorshift"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2593,7 +2593,7 @@ dependencies = [
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum merkle_light 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2522fe9e6a71447b7acc0841bced2517976f982e7ea8d494870eb71464ebc269"
-"checksum mimalloc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "08d3a2c0eeb25e7a6fab0cd2057033c7bb83f537f9789bddb49f077935e0b687"
+"checksum mimalloc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "bd0f8143fb161d2ac2069fdead20b266197c4e54529c3be1d3be930ec8c0a021"
 "checksum miniz-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0300eafb20369952951699b68243ab4334f4b10a88f411c221d444b36c40e649"
 "checksum miniz_oxide 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c468f2369f07d651a5d0bb2c9079f8488a66d5466efe42d0c5c6466edcb7f71e"
 "checksum miniz_oxide_c_api 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fe927a42e3807ef71defb191dc87d4e24479b221e67015fe38ae2b7b447bab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,7 +1170,6 @@ name = "network"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain 0.1.0",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ network = { path = "src/network" }
 transactions = { path = "src/transactions" }
 chain = { path = "src/chain" }
 miner = { path = "src/miner" }
-mimalloc = "0.1.5"
+mimalloc = "0.1.6"
 
 [dev-dependencies.chain]
 path = "src/chain"

--- a/src/network/Cargo.toml
+++ b/src/network/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 [dependencies]
 serde = "1.0.59"
 serde_derive = "1.0.59"
-bytes = "0.4.12"
 rand = "0.6.0"
 byteorder = "1.2.7"
 chrono = "0.4.6"

--- a/src/network/Cargo.toml
+++ b/src/network/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 serde = "1.0.59"
 serde_derive = "1.0.59"
+bytes = "0.4.12"
 rand = "0.6.0"
 byteorder = "1.2.7"
 chrono = "0.4.6"

--- a/src/network/src/bootstrap.rs
+++ b/src/network/src/bootstrap.rs
@@ -29,7 +29,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tokio::executor::Spawn;
 
-const BOOTNODES: &'static [&'static str] = &["139.162.133.241:44034"];
+const BOOTNODES: &'static [&'static str] = &["209.250.247.111:44034"];
 
 pub fn bootstrap(
     network: Arc<Mutex<Network>>,

--- a/src/network/src/bootstrap.rs
+++ b/src/network/src/bootstrap.rs
@@ -29,13 +29,12 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tokio::executor::Spawn;
 
-const BOOTNODES: &'static [&'static str] = &["95.179.130.222:44034"];
-
-pub fn bootstrap(
+pub fn bootstrap<'a>(
     network: Arc<Mutex<Network>>,
     accept_connections: Arc<AtomicBool>,
     db: PersistentDb,
     max_peers: usize,
+    bootnodes: Vec<SocketAddr>,
 ) -> Spawn {
     info!("Bootstrapping...");
 
@@ -65,9 +64,6 @@ pub fn bootstrap(
                 // Connect to bootstrap nodes if we haven't
                 // yet reached the maximum amount of peers.
                 if network_clone.lock().peer_count() < max_peers {
-                    let bootnodes: Vec<SocketAddr> =
-                        BOOTNODES.iter().map(|addr| addr.parse().unwrap()).collect();
-
                     let accept_connections = accept_connections_clone.clone();
                     let network = network_clone.clone();
 
@@ -86,9 +82,6 @@ pub fn bootstrap(
 
         tokio::spawn(fut)
     } else {
-        let bootnodes: Vec<SocketAddr> =
-            BOOTNODES.iter().map(|addr| addr.parse().unwrap()).collect();
-
         let mut peers_to_connect: Vec<SocketAddr> = Vec::with_capacity(bootnodes.len());
 
         for addr in bootnodes.iter().take(max_peers) {

--- a/src/network/src/bootstrap.rs
+++ b/src/network/src/bootstrap.rs
@@ -29,7 +29,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tokio::executor::Spawn;
 
-const BOOTNODES: &'static [&'static str] = &["209.250.247.111:44034"];
+const BOOTNODES: &'static [&'static str] = &["95.179.130.222:44034"];
 
 pub fn bootstrap(
     network: Arc<Mutex<Network>>,

--- a/src/network/src/bootstrap.rs
+++ b/src/network/src/bootstrap.rs
@@ -22,7 +22,6 @@ use futures::Future;
 use futures::Stream;
 use hashdb::HashDB;
 use network::Network;
-use parking_lot::Mutex;
 use persistence::PersistentDb;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicBool;
@@ -30,7 +29,7 @@ use std::sync::Arc;
 use tokio::executor::Spawn;
 
 pub fn bootstrap<'a>(
-    network: Arc<Mutex<Network>>,
+    network: Network,
     accept_connections: Arc<AtomicBool>,
     db: PersistentDb,
     max_peers: usize,
@@ -63,7 +62,7 @@ pub fn bootstrap<'a>(
             .and_then(move |_| {
                 // Connect to bootstrap nodes if we haven't
                 // yet reached the maximum amount of peers.
-                if network_clone.lock().peer_count() < max_peers {
+                if network_clone.peer_count() < max_peers {
                     let accept_connections = accept_connections_clone.clone();
                     let network = network_clone.clone();
 

--- a/src/network/src/common.rs
+++ b/src/network/src/common.rs
@@ -95,7 +95,7 @@ pub fn decode_header(header: &[u8]) -> Result<PacketHeader, NetworkErr> {
 }
 
 /// Verifies the CRC32 checksum of the packet returning `Err(NetworkErr::BadCRC32)` if invalid. 
-pub fn verify_crc32(header: PacketHeader, packet: &[u8]) -> Result<(), NetworkErr> {
+pub fn verify_crc32(header: &PacketHeader, packet: &[u8]) -> Result<(), NetworkErr> {
     let mut crc32 = Hasher::new();
 
     crc32.update(packet);

--- a/src/network/src/common.rs
+++ b/src/network/src/common.rs
@@ -17,42 +17,109 @@
 */
 
 use crate::error::NetworkErr;
+use crate::header::PacketHeader;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use crypto::crc32fast::Hasher;
 use crypto::{Nonce, SessionKey};
 use std::io::Cursor;
 
 pub const NETWORK_VERSION: u8 = 0;
+pub const HEADER_SIZE: usize = 7; // Total of 7 bytes. 1 + 2 + 4;
 
 /// Encrypts and wraps a packet with the default network header
-///
+pub fn wrap_encrypt_packet(packet: &[u8], key: &SessionKey) -> Vec<u8> {
+    let (encrypted, nonce) = crypto::seal(packet, key);
+    wrap_packet(&[&nonce.0, encrypted.as_slice()].concat())
+}
+
+/// Wraps a packet without encrypting it.
+/// 
 /// ### Header fields
 /// 1) Network layer version   - 8bits
-/// 2) Packet length           - 32bits
+/// 2) Packet length           - 16bits
 /// 3) CRC32 of packet + nonce - 32bits
-/// 4) Nonce                   - 12bytes
-/// 5) Packet                  - Binary of packet length
-pub fn wrap_packet(packet: &[u8], key: &SessionKey) -> Vec<u8> {
-    let (encrypted, nonce) = crypto::seal(packet, key);
-    let packet_len = encrypted.len();
-    let mut buf: Vec<u8> = Vec::with_capacity(21 + packet_len);
+/// 4) Packet                  - Binary of packet length
+pub fn wrap_packet(packet: &[u8]) -> Vec<u8> {
+    let packet_len = packet.len();
+    let mut buf: Vec<u8> = Vec::with_capacity(HEADER_SIZE + packet_len);
     let mut crc32 = Hasher::new();
 
-    crc32.update(&encrypted);
-    crc32.update(&nonce.0);
-
+    crc32.update(packet);
     let crc32 = crc32.finalize();
 
     buf.write_u8(NETWORK_VERSION).unwrap();
-    buf.write_u32::<BigEndian>(packet_len as u32).unwrap();
+    buf.write_u16::<BigEndian>(packet_len as u16).unwrap();
     buf.write_u32::<BigEndian>(crc32).unwrap();
-    buf.extend_from_slice(&nonce.0);
-    buf.extend_from_slice(&encrypted);
+    buf.extend_from_slice(packet);
     buf
 }
 
+/// Attempts to decode a `PacketHeader` from a slice of bytes.
+pub fn decode_header(header: &[u8]) -> Result<PacketHeader, NetworkErr> {
+    if header.len() != HEADER_SIZE {
+        return Err(NetworkErr::BadHeader);
+    }
+
+    let mut rdr = Cursor::new(header.to_vec());
+    let network_version = if let Ok(result) = rdr.read_u8() {
+        result
+    } else {
+        return Err(NetworkErr::BadFormat);
+    };
+
+    if network_version != NETWORK_VERSION {
+        return Err(NetworkErr::BadVersion);
+    }
+
+    rdr.set_position(1);
+
+    let packet_len = if let Ok(result) = rdr.read_u16::<BigEndian>() {
+        result
+    } else {
+        return Err(NetworkErr::BadHeader);
+    };
+
+    rdr.set_position(3);
+
+    let crc32 = if let Ok(result) = rdr.read_u32::<BigEndian>() {
+        result
+    } else {
+        return Err(NetworkErr::BadHeader);
+    };
+
+    Ok(PacketHeader {
+        packet_len,
+        crc32,
+        network_version,
+    })
+}
+
+/// Verifies the CRC32 checksum of the packet returning `Err(NetworkErr::BadCRC32)` if invalid. 
+pub fn verify_crc32(header: PacketHeader, packet: &[u8]) -> Result<(), NetworkErr> {
+    let mut crc32 = Hasher::new();
+
+    crc32.update(packet);
+    let crc32 = crc32.finalize();
+
+    // Check CRC32 checksum
+    if crc32 != header.crc32 {
+        return Err(NetworkErr::BadCRC32);
+    }
+
+    Ok(())
+}
+
 /// Attempts to decrypt a packet
-pub fn unwrap_packet(packet: &[u8], key: &SessionKey) -> Result<Vec<u8>, NetworkErr> {
+pub fn decrypt(packet: &[u8], nonce: &Nonce, key: &SessionKey) -> Result<Vec<u8>, NetworkErr> {
+    match crypto::open(packet, key, nonce) {
+        Ok(result) => Ok(result),
+        Err(_) => Err(NetworkErr::EncryptionErr),
+    }
+}
+
+#[cfg(test)]
+/// Attempts to decrypt a packet. Only used for testing
+pub fn unwrap_decrypt_packet(packet: &[u8], key: &SessionKey) -> Result<Vec<u8>, NetworkErr> {
     let mut rdr = Cursor::new(packet.to_vec());
     let version = if let Ok(result) = rdr.read_u8() {
         result
@@ -66,13 +133,17 @@ pub fn unwrap_packet(packet: &[u8], key: &SessionKey) -> Result<Vec<u8>, Network
 
     rdr.set_position(1);
 
-    let packet_len = if let Ok(result) = rdr.read_u32::<BigEndian>() {
+    let packet_len = if let Ok(result) = rdr.read_u16::<BigEndian>() {
         result
     } else {
         return Err(NetworkErr::BadFormat);
     };
 
-    rdr.set_position(5);
+    if packet_len < 12 {
+        return Err(NetworkErr::BadFormat);
+    }
+
+    rdr.set_position(3);
 
     let packet_crc32 = if let Ok(result) = rdr.read_u32::<BigEndian>() {
         result
@@ -81,7 +152,7 @@ pub fn unwrap_packet(packet: &[u8], key: &SessionKey) -> Result<Vec<u8>, Network
     };
 
     let mut buf: Vec<u8> = rdr.into_inner();
-    let _: Vec<u8> = buf.drain(..9).collect();
+    let _: Vec<u8> = buf.drain(..7).collect();
 
     let nonce = if buf.len() > 12 as usize {
         let mut nonce = [0; 12];
@@ -94,7 +165,7 @@ pub fn unwrap_packet(packet: &[u8], key: &SessionKey) -> Result<Vec<u8>, Network
         return Err(NetworkErr::BadFormat);
     };
 
-    let packet = if buf.len() == packet_len as usize {
+    let packet = if buf.len() == (packet_len - 12) as usize {
         buf
     } else {
         return Err(NetworkErr::BadFormat);
@@ -102,8 +173,8 @@ pub fn unwrap_packet(packet: &[u8], key: &SessionKey) -> Result<Vec<u8>, Network
 
     let mut crc32 = Hasher::new();
 
-    crc32.update(&packet);
     crc32.update(&nonce.0);
+    crc32.update(&packet);
 
     let crc32 = crc32.finalize();
 
@@ -112,10 +183,7 @@ pub fn unwrap_packet(packet: &[u8], key: &SessionKey) -> Result<Vec<u8>, Network
         return Err(NetworkErr::BadCRC32);
     }
 
-    match crypto::open(&packet, key, &nonce) {
-        Ok(result) => Ok(result),
-        Err(_) => Err(NetworkErr::EncryptionErr),
-    }
+    decrypt(&packet, &nonce, key)
 }
 
 #[cfg(test)]
@@ -123,10 +191,10 @@ mod tests {
     use super::*;
 
     quickcheck! {
-        fn wrap_unwrap(packet: Vec<u8>) -> bool {
+        fn wrap_encrypt_unwrap(packet: Vec<u8>) -> bool {
             let key = SessionKey([0; 32]);
 
-            assert_eq!(packet, unwrap_packet(&wrap_packet(&packet, &key), &key).unwrap());
+            assert_eq!(packet, unwrap_decrypt_packet(&wrap_encrypt_packet(&packet, &key), &key).unwrap());
             true
         }
     }

--- a/src/network/src/common.rs
+++ b/src/network/src/common.rs
@@ -197,5 +197,12 @@ mod tests {
             assert_eq!(packet, unwrap_decrypt_packet(&wrap_encrypt_packet(&packet, &key), &key).unwrap());
             true
         }
+
+        fn decode_header(packet: Vec<u8>) -> bool {
+            let wrapped = wrap_packet(&packet);
+            let (header, tail) = wrapped.split_at(7);
+            super::decode_header(&header).unwrap();
+            true
+        }
     }
 }

--- a/src/network/src/connection.rs
+++ b/src/network/src/connection.rs
@@ -136,27 +136,23 @@ fn process_connection(
             let mut peers = network_clone3.peers.write();
 
             if let Some(peer) = peers.get_mut(&addr) {
-                // Write a connect packet if we are the client
-                // and we have not yet sent a connect packet.
+                // Write a connect packet if we are the client.
                 if let ConnectionType::Client = client_or_server {
-                    if !peer.sent_connect {
-                        // Send `Connect` packet.
-                        let mut connect = Connect::new(node_id.clone(), peer.pk);
-                        connect.sign(&skey);
+                    // Send `Connect` packet.
+                    let mut connect = Connect::new(node_id.clone(), peer.pk);
+                    connect.sign(&skey);
 
-                        let packet = connect.to_bytes();
-                        let packet = crate::common::wrap_packet(&packet);
-                        debug!("Sending connect packet to {}", addr);
+                    let packet = connect.to_bytes();
+                    let packet = crate::common::wrap_packet(&packet);
+                    debug!("Sending connect packet to {}", addr);
 
-                        writer
-                            .poll_write(&packet)
-                            .map_err(|err| warn!("write failed = {:?}", err))
-                            .and_then(|_| Ok(()))
-                            .unwrap();
+                    writer
+                        .poll_write(&packet)
+                        .map_err(|err| warn!("write failed = {:?}", err))
+                        .and_then(|_| Ok(()))
+                        .unwrap();
 
-                        peer.sent_connect = true;
-                        return ok(writer);
-                    }
+                    return ok(writer);
                 }
             } else {
                 return err("no peer found");

--- a/src/network/src/connection.rs
+++ b/src/network/src/connection.rs
@@ -247,7 +247,7 @@ fn process_connection(
                             } else {
                                 // We are expecting an un-encrypted `Connect` packet
                                 // so we make it just pass through.
-                                buf.copy_from_slice(&buffer);
+                                buf = buffer;
                             }
 
                             buf

--- a/src/network/src/connection.rs
+++ b/src/network/src/connection.rs
@@ -45,7 +45,7 @@ pub fn start_listener(network: Arc<Mutex<Network>>, accept_connections: Arc<Atom
     info!("Starting TCP listener on port {}", PORT);
 
     // Bind the server's socket.
-    let addr = format!("127.0.0.1:{}", PORT).parse().unwrap();
+    let addr = format!("0.0.0.0:{}", PORT).parse().unwrap();
     let listener = TcpListener::bind(&addr).expect("unable to bind TCP listener");
     let accept_connections_clone = accept_connections.clone();
 

--- a/src/network/src/connection.rs
+++ b/src/network/src/connection.rs
@@ -187,7 +187,12 @@ fn process_connection(
                     }
                 });
             
-            ok(fut)
+            tokio::spawn(fut.then(move |_| {
+                debug!("Write half of {} closed", addr);
+                Ok(())
+            }));
+
+            ok(())
         });
         
     let socket_reader = iter
@@ -346,10 +351,7 @@ fn process_connection(
         ok(())
     }));
 
-    tokio::spawn(socket_writer.then(move |_| {
-        debug!("Write half of {} closed", addr);
-        Ok(())
-    }))
+    tokio::spawn(socket_writer)
 }
 
 // #[cfg(test)]

--- a/src/network/src/connection.rs
+++ b/src/network/src/connection.rs
@@ -16,13 +16,14 @@
   along with the Purple Core Library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use crate::common;
 use crate::error::NetworkErr;
 use crate::interface::NetworkInterface;
 use crate::network::Network;
 use crate::packet::Packet;
 use crate::packets::connect::Connect;
 use crate::peer::{ConnectionType, Peer};
-use parking_lot::Mutex;
+use crypto::Nonce;
 use std::io::BufReader;
 use std::iter;
 use std::net::SocketAddr;
@@ -35,13 +36,14 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::future::{ok, err};
 use tokio::prelude::*;
 use tokio_io_timeout::TimeoutStream;
+use bytes::BytesMut;
 
 /// Purple network port
 pub const PORT: u16 = 44034;
 const PEER_TIMEOUT: u64 = 3000;
 
 /// Initializes the listener for the given network
-pub fn start_listener(network: Arc<Mutex<Network>>, accept_connections: Arc<AtomicBool>) -> Spawn {
+pub fn start_listener(network: Network, accept_connections: Arc<AtomicBool>) -> Spawn {
     info!("Starting TCP listener on port {}", PORT);
 
     // Bind the server's socket.
@@ -67,7 +69,7 @@ pub fn start_listener(network: Arc<Mutex<Network>>, accept_connections: Arc<Atom
 }
 
 pub fn connect_to_peer(
-    network: Arc<Mutex<Network>>,
+    network: Network,
     accept_connections: Arc<AtomicBool>,
     addr: &SocketAddr,
 ) -> Spawn {
@@ -81,7 +83,7 @@ pub fn connect_to_peer(
 }
 
 fn process_connection(
-    network: Arc<Mutex<Network>>,
+    mut network: Network,
     sock: TcpStream,
     accept_connections: Arc<AtomicBool>,
     client_or_server: ConnectionType,
@@ -100,14 +102,10 @@ fn process_connection(
         ConnectionType::Server => info!("Received connection request from {}", addr),
     };
 
-    let network = network.clone();
-
     // Create new peer and add it to the peer table
     let peer = Peer::new(None, addr, client_or_server);
 
     let (node_id, skey) = {
-        let mut network = network.lock();
-
         if let Err(NetworkErr::MaximumPeersReached) = network.add_peer(addr, peer.clone()) {
             // Stop accepting peers
             accept_connections.store(false, Ordering::Relaxed);
@@ -127,14 +125,13 @@ fn process_connection(
     let iter = stream::iter_ok::<_, io::Error>(iter::repeat(()));
     let network_clone = network.clone();
     let network_clone2 = network.clone();
-    let network = network_clone.clone();
     let refuse_connection_clone = refuse_connection.clone();
 
     let writer_iter = stream::iter_ok::<_, &'static str>(iter::repeat(()));
     let socket_writer = writer_iter.fold(writer, move |mut writer, _| {
-        let mut network = network_clone.lock();
+        let mut peers = network_clone.peers.write();
 
-        if let Some(peer) = network.peers.get_mut(&addr) {
+        if let Some(peer) = peers.get_mut(&addr) {
             // Write a connect packet if we are the client
             // and we have not yet sent a connect packet.
             if let ConnectionType::Client = client_or_server {
@@ -180,11 +177,95 @@ fn process_connection(
     let socket_reader = iter
         .take_while(move |_| ok(!refuse_connection_clone.load(Ordering::Relaxed)))
         .fold(reader, move |reader, _| {
-            let network = network.clone();
+            let mut network = network.clone();
+            let network_clone = network.clone();
 
-            // Read a line off the socket, failing if we're at EOF.
-            let line = io::read_until(reader, b'\n', Vec::new());
-            let line = line.and_then(move |(reader, vec)| {
+            // Read header
+            let line = io::read_exact(reader, BytesMut::with_capacity(common::HEADER_SIZE))
+                // Decode header
+                .and_then(move |(reader, buffer)| {
+                    let header = common::decode_header(&buffer).map_err(|err| 
+                        io::Error::new(
+                            io::ErrorKind::Other,
+                            format!("Header read error for {}: {:?}", addr, err)
+                        )
+                    )?;
+
+                    // Only accept our current network version
+                    if header.network_version != common::NETWORK_VERSION {
+                        return Err(
+                            io::Error::new(
+                                io::ErrorKind::Other,
+                                format!("Header read error for {}: {:?}", addr, NetworkErr::BadVersion)
+                            )
+                        );
+                    }
+
+                    Ok((reader, header))
+                })
+                // Read packet from stream
+                .and_then(move |(reader, header)| {
+                    io::read_exact(
+                        reader, 
+                        BytesMut::with_capacity(header.packet_len as usize)
+                    ).map(|(reader, buffer)| (reader, header, buffer))
+                })
+                // Verify crc32 checksum
+                .and_then(move |(reader, header, buffer)| {
+                    common::verify_crc32(&header, &buffer).map_err(|err| 
+                        io::Error::new(
+                            io::ErrorKind::Other,
+                            format!("Header read error for {}: {:?}", addr, err)
+                        )
+                    )?;
+
+                    Ok((reader, header, buffer))
+                })
+                // Decrypt packet
+                .and_then(move |(reader, header, mut buffer)|{
+                    let network = network_clone;
+                    let packet: Vec<u8> = {
+                        let mut peers = network.peers.write();
+
+                        if let Some(peer) = peers.get_mut(&addr) {
+                            let mut buf: Vec<u8> = Vec::new();
+
+                            // Decrypt packet if we are connected
+                            if peer.sent_connect {
+                                // Decode nonce which is always the
+                                // first 12 bytes in the packet.
+                                let nonce_buf = buffer.split_to(11);
+                                let mut nonce: [u8; 12] = [0; 12];
+                                nonce.copy_from_slice(&nonce_buf);
+                                let nonce = Nonce(nonce);
+
+                                buf = common::decrypt(&buffer, &nonce, peer.tx.as_ref().unwrap()).map_err(|_|
+                                    io::Error::new(
+                                        io::ErrorKind::Other,
+                                        format!("Encryption error for {}", addr)
+                                    )
+                                )?;
+                            } else {
+                                // We are expecting an un-encrypted `Connect` packet
+                                // so we make it just pass through.
+                                buf.copy_from_slice(&buffer);
+                            }
+
+                            buf
+                        } else {
+                            return Err(
+                                io::Error::new(
+                                    io::ErrorKind::Other,
+                                    format!("Lost connection to {}", addr)
+                                )
+                            );
+                        }
+                    };
+
+                    Ok((reader, header, packet))
+                });
+
+            let line = line.and_then(move |(reader, _, vec)| {
                 if vec.len() == 0 {
                     Err(io::Error::new(io::ErrorKind::BrokenPipe, "broken pipe"))
                 } else {
@@ -197,7 +278,7 @@ fn process_connection(
 
             line
                 .map(move |(reader, message)| {
-                    let result = network.lock().process_packet(&addr, &message);
+                    let result = network.process_packet(&addr, &message);
                     (reader, result)
                 })
                 .map(move |(reader, result)| {
@@ -212,7 +293,7 @@ fn process_connection(
                             refuse_connection.store(true, Ordering::Relaxed);
 
                             // Also, ban the peer
-                            network.lock().ban_ip(&addr).unwrap();
+                            network.ban_ip(&addr).unwrap();
                         }
 
                         Err(NetworkErr::SelfConnect) => {
@@ -239,7 +320,6 @@ fn process_connection(
 
     // Spawn a task to process the connection
     tokio::spawn(socket_reader.then(move |_| {
-        let mut network = network.lock();
         network.remove_peer_with_addr(&addr);
 
         // Re-enable connections

--- a/src/network/src/error.rs
+++ b/src/network/src/error.rs
@@ -63,4 +63,7 @@ pub enum NetworkErr {
 
     /// We have connected to ourselves
     SelfConnect,
+
+    /// Could not send a packet. Maybe the outbound buffer is full?
+    CouldNotSend,
 }

--- a/src/network/src/error.rs
+++ b/src/network/src/error.rs
@@ -55,6 +55,9 @@ pub enum NetworkErr {
     /// The CRC32 checksum was invalid
     BadCRC32,
 
+    /// The provided header is invalid
+    BadHeader,
+
     /// The network version found in the packet is invalid
     BadVersion,
 

--- a/src/network/src/error.rs
+++ b/src/network/src/error.rs
@@ -64,6 +64,7 @@ pub enum NetworkErr {
     /// We have connected to ourselves
     SelfConnect,
 
-    /// Could not send a packet. Maybe the outbound buffer is full?
+    /// Could not send a packet. Maybe the outbound buffer is full? 
+    /// Or maybe the peer does not have an encryption key ready?
     CouldNotSend,
 }

--- a/src/network/src/error.rs
+++ b/src/network/src/error.rs
@@ -57,4 +57,7 @@ pub enum NetworkErr {
 
     /// The network version found in the packet is invalid
     BadVersion,
+
+    /// We have connected to ourselves
+    SelfConnect,
 }

--- a/src/network/src/handlers.rs
+++ b/src/network/src/handlers.rs
@@ -84,7 +84,7 @@ pub fn start_chains_switch_poll(
 /// Listens for blocks on chain receivers and
 /// forwards them to their respective chains.
 pub fn start_block_listeners(
-    network: Arc<Mutex<Network>>,
+    network: Network,
     hard_chain: HardChainRef,
     state_chain: StateChainRef,
     hard_receiver: Receiver<(SocketAddr, Arc<HardBlock>)>,
@@ -102,8 +102,6 @@ pub fn start_block_listeners(
 
                 match chain_result {
                     Ok(()) => {
-                        let network = network.lock();
-
                         // Forward block
                         let mut packet = ForwardBlock::new(
                             network.our_node_id().clone(),
@@ -137,8 +135,6 @@ pub fn start_block_listeners(
 
                 match chain_result {
                     Ok(()) => {
-                        let network = network.lock();
-
                         // Forward block
                         let mut packet = ForwardBlock::new(
                             network.our_node_id().clone(),

--- a/src/network/src/header.rs
+++ b/src/network/src/header.rs
@@ -1,0 +1,30 @@
+/*
+  Copyright (C) 2018-2019 The Purple Core Developers.
+  This file is part of the Purple Core Library.
+
+  The Purple Core Library is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Purple Core Library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with the Purple Core Library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#[derive(Clone, Debug)]
+/// Struct representing the header wrapping a network packet.
+pub struct PacketHeader {
+    /// The version of the network layer
+    pub(crate) network_version: u8,
+
+    /// The crc32 of the packet data
+    pub(crate) crc32: u32,
+
+    /// The size of the packet
+    pub(crate) packet_len: u16,
+}

--- a/src/network/src/interface.rs
+++ b/src/network/src/interface.rs
@@ -77,7 +77,7 @@ pub trait NetworkInterface {
 
     /// Sends a raw packet to a specific peer. This
     /// means that the packet will be un-encrypted.
-    fn send_raw(&self, peer: &SocketAddr, packet: Vec<u8>) -> Result<(), NetworkErr>;
+    fn send_raw(&self, peer: &SocketAddr, packet: &[u8]) -> Result<(), NetworkErr>;
 
     /// This behaves similarly to `send_unsigned()` but it sends a raw packet.
     fn send_raw_unsigned<P: Packet>(

--- a/src/network/src/interface.rs
+++ b/src/network/src/interface.rs
@@ -22,6 +22,8 @@ use crate::packet::Packet;
 use crate::peer::Peer;
 use crypto::NodeId;
 use std::net::SocketAddr;
+use parking_lot::RwLock;
+use hashbrown::HashMap;
 use std::sync::Arc;
 
 #[cfg(not(test))]
@@ -93,19 +95,11 @@ pub trait NetworkInterface {
     /// Bans any further connections from the given ip.
     fn ban_ip(&self, peer: &SocketAddr) -> Result<(), NetworkErr>;
 
-    /// Attempts to retrieve a reference to
-    /// the peer entry of the given `NodeId`.
-    fn fetch_peer(&self, peer: &SocketAddr) -> Result<&Peer, NetworkErr>;
-
-    /// Attempts to retrieve a mutable reference to
-    /// the peer entry of the given ip.
-    fn fetch_peer_mut(&mut self, peer: &SocketAddr) -> Result<&mut Peer, NetworkErr>;
-
     /// Returns a reference to our node id.
     fn our_node_id(&self) -> &NodeId;
 
-    /// Returns an iterator on the listed peers
-    fn peers<'a>(&'a self) -> Box<dyn Iterator<Item = (&SocketAddr, &Peer)> + 'a>;
+    /// Returns a reference to the peer table RwLock.
+    fn peers(&self) -> Arc<RwLock<HashMap<SocketAddr, Peer>>>;
 
     /// Returns a reference to the `HardChain`.
     fn hard_chain_ref(&self) -> HardChainRef;

--- a/src/network/src/interface.rs
+++ b/src/network/src/interface.rs
@@ -50,7 +50,7 @@ pub trait NetworkInterface {
     fn disconnect_from_ip(&mut self, ip: &SocketAddr) -> Result<(), NetworkErr>;
 
     /// Sends a packet to a specific peer.
-    fn send_to_peer(&self, peer: &SocketAddr, packet: &[u8]) -> Result<(), NetworkErr>;
+    fn send_to_peer(&self, peer: &SocketAddr, packet: Vec<u8>) -> Result<(), NetworkErr>;
 
     /// Sends a packet to all peers.
     fn send_to_all(&self, packet: &[u8]) -> Result<(), NetworkErr>;
@@ -77,7 +77,7 @@ pub trait NetworkInterface {
 
     /// Sends a raw packet to a specific peer. This
     /// means that the packet will be un-encrypted.
-    fn send_raw(&self, peer: &SocketAddr, packet: &[u8]) -> Result<(), NetworkErr>;
+    fn send_raw(&self, peer: &SocketAddr, packet: Vec<u8>) -> Result<(), NetworkErr>;
 
     /// This behaves similarly to `send_unsigned()` but it sends a raw packet.
     fn send_raw_unsigned<P: Packet>(

--- a/src/network/src/lib.rs
+++ b/src/network/src/lib.rs
@@ -26,6 +26,7 @@ extern crate log;
 #[cfg(test)]
 extern crate tempdir;
 
+extern crate bytes;
 extern crate byteorder;
 extern crate chain;
 extern crate chrono;

--- a/src/network/src/lib.rs
+++ b/src/network/src/lib.rs
@@ -56,6 +56,7 @@ mod network;
 mod packet;
 pub mod packets;
 mod peer;
+mod header;
 
 pub use bootstrap::*;
 pub use connection::*;

--- a/src/network/src/lib.rs
+++ b/src/network/src/lib.rs
@@ -26,7 +26,6 @@ extern crate log;
 #[cfg(test)]
 extern crate tempdir;
 
-extern crate bytes;
 extern crate byteorder;
 extern crate chain;
 extern crate chrono;

--- a/src/network/src/mock.rs
+++ b/src/network/src/mock.rs
@@ -87,7 +87,7 @@ impl NetworkInterface for MockNetwork {
             peers.insert(address.clone(), peer);
         }
 
-        self.send_raw(address, connect).unwrap();
+        self.send_raw(address, &connect).unwrap();
         Ok(())
     }
 
@@ -131,7 +131,7 @@ impl NetworkInterface for MockNetwork {
         }
     }
 
-    fn send_raw(&self, peer: &SocketAddr, packet: Vec<u8>) -> Result<(), NetworkErr> {
+    fn send_raw(&self, peer: &SocketAddr, packet: &[u8]) -> Result<(), NetworkErr> {
         let id = if let Some(id) = self.address_mappings.get(peer) {
             id
         } else {
@@ -139,7 +139,7 @@ impl NetworkInterface for MockNetwork {
         };
 
         if let Some(mailbox) = self.mailboxes.get(&id) {
-            mailbox.send((self.ip.clone(), packet)).unwrap();
+            mailbox.send((self.ip.clone(), packet.to_vec())).unwrap();
             Ok(())
         } else {
             Err(NetworkErr::PeerNotFound)
@@ -224,7 +224,7 @@ impl NetworkInterface for MockNetwork {
         }
 
         let packet = packet.to_bytes();
-        self.send_raw(peer, packet)?;
+        self.send_raw(peer, &packet)?;
 
         Ok(())
     }

--- a/src/network/src/mock.rs
+++ b/src/network/src/mock.rs
@@ -114,7 +114,7 @@ impl NetworkInterface for MockNetwork {
         if let Some(mailbox) = self.mailboxes.get(&id) {
             let peer = self.peers.get(peer).unwrap();
             let key = peer.rx.as_ref().unwrap();
-            let packet = crate::common::wrap_packet(packet, key);
+            let packet = crate::common::wrap_encrypt_packet(packet, key);
             mailbox.send((self.ip.clone(), packet)).unwrap();
             Ok(())
         } else {
@@ -278,7 +278,7 @@ impl NetworkInterface for MockNetwork {
         } else {
             debug!("Received packet from {}: {}", addr, hex::encode(packet));
 
-            let packet = crate::common::unwrap_packet(packet, tx.as_ref().unwrap())?;
+            let packet = crate::common::unwrap_decrypt_packet(packet, tx.as_ref().unwrap())?;
             let packet_type = packet[0];
 
             match packet_type {

--- a/src/network/src/mock.rs
+++ b/src/network/src/mock.rs
@@ -25,7 +25,7 @@ use chain::*;
 use crypto::NodeId;
 use crypto::SecretKey as Sk;
 use hashbrown::HashMap;
-use parking_lot::Mutex;
+use parking_lot::{RwLock, Mutex};
 use std::net::SocketAddr;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Arc;
@@ -39,6 +39,7 @@ pub struct MockNetwork {
 
     /// Our receiver
     rx: Receiver<(SocketAddr, Vec<u8>)>,
+
     /// Reference to the `HardChain`
     hard_chain_ref: HardChainRef,
 
@@ -55,7 +56,7 @@ pub struct MockNetwork {
     pub(crate) address_mappings: HashMap<SocketAddr, NodeId>,
 
     /// Mapping between connected peers and their information
-    pub(crate) peers: HashMap<SocketAddr, Peer>,
+    pub(crate) peers: Arc<RwLock<HashMap<SocketAddr, Peer>>>,
 
     /// Our ip
     ip: SocketAddr,
@@ -80,9 +81,13 @@ impl NetworkInterface for MockNetwork {
         let connect = connect_packet.to_bytes();
 
         peer.sent_connect = true;
-        self.peers.insert(address.clone(), peer);
-        self.send_raw(address, &connect).unwrap();
+        
+        {
+            let mut peers = self.peers.write(); 
+            peers.insert(address.clone(), peer);
+        }
 
+        self.send_raw(address, &connect).unwrap();
         Ok(())
     }
 
@@ -91,16 +96,19 @@ impl NetworkInterface for MockNetwork {
     }
 
     fn is_connected_to(&self, address: &SocketAddr) -> bool {
-        self.peers.get(address).is_some()
+        let peers = self.peers.read();
+        peers.get(address).is_some()
     }
 
     fn disconnect(&mut self, peer: &NodeId) -> Result<(), NetworkErr> {
-        self.peers.retain(|_, p| p.id.as_ref() != Some(peer));
+        let mut peers = self.peers.write();
+        peers.retain(|_, p| p.id.as_ref() != Some(peer));
         Ok(())
     }
 
     fn disconnect_from_ip(&mut self, ip: &SocketAddr) -> Result<(), NetworkErr> {
-        self.peers.remove(ip);
+        let mut peers = self.peers.write();
+        peers.remove(ip);
         Ok(())
     }
 
@@ -112,7 +120,8 @@ impl NetworkInterface for MockNetwork {
         };
 
         if let Some(mailbox) = self.mailboxes.get(&id) {
-            let peer = self.peers.get(peer).unwrap();
+            let peers = self.peers.read();
+            let peer = peers.get(peer).unwrap();
             let key = peer.rx.as_ref().unwrap();
             let packet = crate::common::wrap_encrypt_packet(packet, key);
             mailbox.send((self.ip.clone(), packet)).unwrap();
@@ -241,16 +250,18 @@ impl NetworkInterface for MockNetwork {
             panic!("We received a packet from ourselves! This is illegal");
         }
 
-        // Insert to peer table if this is the first received packet.
-        if self.peers.get(addr).is_none() {
-            self.peers.insert(
-                addr.clone(),
-                Peer::new(None, addr.clone(), ConnectionType::Server),
-            );
-        }
-
         let (tx, is_none_id, conn_type) = {
-            let peer = self.peers.get(addr).unwrap();
+            let mut peers = self.peers.write();
+
+            // Insert to peer table if this is the first received packet.
+            if peers.get(addr).is_none() {
+                peers.insert(
+                    addr.clone(),
+                    Peer::new(None, addr.clone(), ConnectionType::Server),
+                );
+            }
+
+            let peer = peers.get(addr).unwrap();
             (peer.tx.clone(), peer.id.is_none(), peer.connection_type)
         };
 
@@ -310,28 +321,12 @@ impl NetworkInterface for MockNetwork {
         unimplemented!();
     }
 
-    fn fetch_peer(&self, peer: &SocketAddr) -> Result<&Peer, NetworkErr> {
-        if let Some(peer) = self.peers.get(peer) {
-            Ok(peer)
-        } else {
-            Err(NetworkErr::PeerNotFound)
-        }
-    }
-
-    fn fetch_peer_mut(&mut self, peer: &SocketAddr) -> Result<&mut Peer, NetworkErr> {
-        if let Some(peer) = self.peers.get_mut(peer) {
-            Ok(peer)
-        } else {
-            Err(NetworkErr::PeerNotFound)
-        }
-    }
-
     fn our_node_id(&self) -> &NodeId {
         &self.node_id
     }
 
-    fn peers<'a>(&'a self) -> Box<dyn Iterator<Item = (&SocketAddr, &Peer)> + 'a> {
-        Box::new(self.peers.iter())
+    fn peers(&self) -> Arc<RwLock<HashMap<SocketAddr, Peer>>> {
+        self.peers.clone()
     }
 }
 
@@ -357,7 +352,7 @@ impl MockNetwork {
             state_chain_sender,
             hard_chain_ref,
             state_chain_ref,
-            peers: HashMap::new(),
+            peers: Arc::new(RwLock::new(HashMap::new())),
             node_id,
             secret_key,
             ip,

--- a/src/network/src/network.rs
+++ b/src/network/src/network.rs
@@ -171,11 +171,21 @@ impl NetworkInterface for Network {
         exception: &SocketAddr,
         packet: &mut P,
     ) -> Result<(), NetworkErr> {
-        unimplemented!();
+        if packet.signature().is_none() {
+            packet.sign(&self.secret_key);
+        }
+
+        let packet = packet.to_bytes();
+        self.send_to_all_except(exception, &packet)
     }
 
     fn send_to_all_unsigned<P: Packet>(&self, packet: &mut P) -> Result<(), NetworkErr> {
-        unimplemented!();
+        if packet.signature().is_none() {
+            packet.sign(&self.secret_key);
+        }
+
+        let packet = packet.to_bytes();
+        self.send_to_all(&packet)
     }
 
     fn send_raw(&self, peer: &SocketAddr, packet: &[u8]) -> Result<(), NetworkErr> {

--- a/src/network/src/network.rs
+++ b/src/network/src/network.rs
@@ -235,10 +235,11 @@ impl NetworkInterface for Network {
         self.send_to_all(&packet)
     }
 
-    fn send_raw(&self, peer: &SocketAddr, packet: Vec<u8>) -> Result<(), NetworkErr> {
+    fn send_raw(&self, peer: &SocketAddr, packet: &[u8]) -> Result<(), NetworkErr> {
         let peers = self.peers.read();
 
         if let Some(peer) = peers.get(peer) {
+            let packet = crate::common::wrap_packet(&packet);
             peer.send_packet(packet)
         } else {
             Err(NetworkErr::PeerNotFound)
@@ -270,7 +271,7 @@ impl NetworkInterface for Network {
         }
 
         let packet = packet.to_bytes();
-        self.send_raw(peer, packet)?;
+        self.send_raw(peer, &packet)?;
 
         Ok(())
     }

--- a/src/network/src/network.rs
+++ b/src/network/src/network.rs
@@ -286,19 +286,11 @@ impl NetworkInterface for Network {
         unimplemented!();
     }
 
-    fn fetch_peer(&self, peer: &SocketAddr) -> Result<&Peer, NetworkErr> {
-        unimplemented!();
-    }
-
-    fn fetch_peer_mut(&mut self, peer: &SocketAddr) -> Result<&mut Peer, NetworkErr> {
-        unimplemented!();
-    }
-
     fn our_node_id(&self) -> &NodeId {
         &self.node_id
     }
 
-    fn peers<'a>(&'a self) -> Box<dyn Iterator<Item = (&SocketAddr, &Peer)> + 'a> {
-        unimplemented!();
+    fn peers(&self) -> Arc<RwLock<HashMap<SocketAddr, Peer>>> {
+        self.peers.clone()
     }
 }

--- a/src/network/src/packets/connect.rs
+++ b/src/network/src/packets/connect.rs
@@ -78,8 +78,7 @@ impl Packet for Connect {
     fn to_bytes(&self) -> Vec<u8> {
         let mut buffer: Vec<u8> = Vec::new();
         let packet_type: u8 = Self::PACKET_TYPE;
-
-        let mut signature = if let Some(signature) = &self.signature {
+        let signature = if let Some(signature) = &self.signature {
             signature.inner_bytes()
         } else {
             panic!("Signature field is missing");
@@ -103,7 +102,6 @@ impl Packet for Connect {
         buffer.extend_from_slice(&node_id.0);
         buffer.extend_from_slice(&signature);
         buffer.extend_from_slice(timestamp.as_bytes());
-
         buffer
     }
 

--- a/src/network/src/packets/connect.rs
+++ b/src/network/src/packets/connect.rs
@@ -234,6 +234,7 @@ impl Packet for Connect {
 
         // If we are the server, also send a connect packet back
         if let ConnectionType::Server = conn_type {
+            debug!("Sending connect packet to {}", addr);
             let mut packet = Connect::new(our_node_id, our_pk.unwrap());
             network.send_raw_unsigned::<Connect>(addr, &mut packet)?;
         }

--- a/src/network/src/packets/request_peers.rs
+++ b/src/network/src/packets/request_peers.rs
@@ -206,8 +206,10 @@ impl Packet for RequestPeers {
 
         let num_of_peers = packet.requested_peers as usize;
         let our_node_id = network.our_node_id();
-        let addresses: Vec<SocketAddr> = network
-            .peers()
+        let peers = network.peers();
+        let peers = peers.read(); 
+        let addresses: Vec<SocketAddr> = peers
+            .iter()
             // Don't send the address of the requester
             .filter(|(peer_addr, peer)| {
                 peer.id.is_some() && peer.id != Some(packet.node_id.clone()) && *peer_addr != addr

--- a/src/network/src/packets/send_peers.rs
+++ b/src/network/src/packets/send_peers.rs
@@ -103,8 +103,7 @@ impl Packet for SendPeers {
     fn to_bytes(&self) -> Vec<u8> {
         let mut buffer: Vec<u8> = Vec::new();
         let packet_type: u8 = Self::PACKET_TYPE;
-
-        let mut signature = if let Some(signature) = &self.signature {
+        let signature = if let Some(signature) = &self.signature {
             signature.inner_bytes()
         } else {
             panic!("Signature field is missing");
@@ -131,7 +130,6 @@ impl Packet for SendPeers {
         buffer.extend_from_slice(&signature);
         buffer.extend_from_slice(timestamp.as_bytes());
         buffer.extend_from_slice(&peers);
-
         buffer
     }
 

--- a/src/network/src/peer.rs
+++ b/src/network/src/peer.rs
@@ -54,7 +54,7 @@ pub struct Peer {
     /// The ip address of the peer
     pub ip: SocketAddr,
 
-    /// Wether the peer has send a `Connect` packet or not.
+    /// Wether the peer has sent a `Connect` packet or not.
     pub sent_connect: bool,
 
     /// Wether we have asked the peer to send us a peer list

--- a/src/network/src/peer.rs
+++ b/src/network/src/peer.rs
@@ -16,9 +16,10 @@
   along with the Purple Core Library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use crate::error::NetworkErr;
 use crypto::NodeId;
 use crypto::{gen_kx_keypair, KxPublicKey as Pk, KxSecretKey as Sk, SessionKey};
-use std::collections::VecDeque;
+use tokio::sync::mpsc::Sender;
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 
@@ -29,7 +30,7 @@ pub enum ConnectionType {
 }
 
 /// Size of the outbound buffer.
-pub const OUTBOUND_BUF_SIZE: usize = 1000;
+pub const OUTBOUND_BUF_SIZE: usize = 8000;
 
 #[derive(Debug, Clone)]
 pub struct Peer {
@@ -62,7 +63,7 @@ pub struct Peer {
 
     /// Buffer storing packets that are to be
     /// sent to the peer.
-    pub outbound_buffer: VecDeque<Vec<u8>>,
+    pub outbound_buffer: Option<Sender<Vec<u8>>>,
 
     /// Session generated public key
     pub pk: Pk,
@@ -78,9 +79,13 @@ pub struct Peer {
 }
 
 impl Peer {
-    pub fn new(id: Option<NodeId>, ip: SocketAddr, connection_type: ConnectionType) -> Peer {
+    pub fn new(
+        id: Option<NodeId>, 
+        ip: SocketAddr, 
+        connection_type: ConnectionType, 
+        outbound_buffer: Option<Sender<Vec<u8>>>,
+    ) -> Peer {
         let (pk, sk) = gen_kx_keypair();
-        let outbound_buffer = VecDeque::with_capacity(OUTBOUND_BUF_SIZE);
 
         Peer {
             id: id,
@@ -105,6 +110,12 @@ impl Peer {
     pub fn set_session_keys(&mut self, rx: SessionKey, tx: SessionKey) {
         self.rx = Some(rx);
         self.tx = Some(tx);
+    }
+
+    /// Attempts to place a packet in the outbound buffer of a `Peer`.
+    pub fn send_packet(&self, packet: Vec<u8>) -> Result<(), NetworkErr> {
+        let mut sender = self.outbound_buffer.as_ref().unwrap().clone();
+        sender.try_send(packet).map_err(|_| NetworkErr::CouldNotSend)
     }
 }
 

--- a/src/purple/main.rs
+++ b/src/purple/main.rs
@@ -126,7 +126,7 @@ fn main() {
     info!("Setting up the network...");
 
     let (node_id, skey) = fetch_credentials(&mut node_storage);
-    let network = Arc::new(Mutex::new(Network::new(
+    let network = Network::new(
         node_id,
         argv.network_name.to_owned(),
         skey,
@@ -135,7 +135,7 @@ fn main() {
         state_tx,
         hard_chain.clone(),
         state_chain.clone(),
-    )));
+    );
     let accept_connections = Arc::new(AtomicBool::new(true));
 
     // Start the tokio runtime

--- a/src/purple/main.rs
+++ b/src/purple/main.rs
@@ -59,12 +59,14 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::net::SocketAddr;
 
 // Use mimalloc allocator
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
 const DEFAULT_NETWORK_NAME: &'static str = "purple";
+const BOOTNODES: &'static [&'static str] = &["95.179.130.222:44034"];
 
 fn main() {
     env_logger::init();
@@ -109,7 +111,7 @@ fn main() {
     let state_chain_db = PersistentDb::new(state_chain_db.clone(), None);
     let hard_chain_db = PersistentDb::new(hard_chain_db.clone(), None);
 
-    let ( hard_chain, state_chain) = chain::init(
+    let (hard_chain, state_chain) = chain::init(
         hard_chain_db,
         state_chain_db,
         state_db,
@@ -158,6 +160,7 @@ fn main() {
             accept_connections,
             node_storage.clone(),
             argv.max_peers,
+            argv.bootnodes.clone()
         );
 
         Ok(())
@@ -202,6 +205,7 @@ fn get_storage_path(network_name: &str) -> PathBuf {
 
 struct Argv {
     network_name: String,
+    bootnodes: Vec<SocketAddr>,
     mempool_size: u16,
     max_peers: usize,
     no_mempool: bool,
@@ -238,6 +242,19 @@ fn parse_cli_args() -> Argv {
             Arg::with_name("no_rpc")
                 .long("no-rpc")
                 .help("Start the node without the json-rpc interface")
+        )
+        .arg(
+            Arg::with_name("no_bootnodes")
+                .long("no-bootnodes")
+                .help("Start the node without attempting to connect to any bootnode")
+        )
+        .arg(
+            Arg::with_name("bootnodes")
+                .long("bootnodes")
+                .value_name("IP_ADDRESES")
+                .min_values(1)
+                .conflicts_with("no_bootnodes")
+                .help("A list of bootnodes to initially connect to")
         )
         .arg(
             Arg::with_name("interactive")
@@ -293,14 +310,29 @@ fn parse_cli_args() -> Argv {
         8
     };
 
+    let bootnodes: Vec<SocketAddr> = if let Some(bootnodes) = matches.values_of("bootnodes") {
+        bootnodes
+            .map(|addr| unwrap!(addr.parse(), "Bad value for <IP_ADDRESSES>"))
+            .collect()
+    } else {
+        BOOTNODES.iter().map(|addr| addr.parse().unwrap()).collect()
+    };
+
     let archival_mode: bool = !matches.is_present("prune");
     let mine_easy: bool = matches.is_present("mine_easy");
     let mine_hard: bool = matches.is_present("mine_hard");
     let no_mempool: bool = matches.is_present("no_mempool");
     let interactive: bool = matches.is_present("interactive");
     let wipe: bool = matches.is_present("wipe");
+    let no_bootnodes: bool = matches.is_present("no_bootnodes");
+    let bootnodes = if no_bootnodes {
+        Vec::new()
+    } else {
+        bootnodes
+    };
 
     Argv {
+        bootnodes,
         network_name,
         mine_easy,
         mine_hard,


### PR DESCRIPTION
The changes in this PR enable nodes running Purple Core to be able to connect to other nodes via TCP. 

### Changes
* All packets are now wrapped with a fixed header of 7 bytes. Check [this](https://github.com/purpleprotocol/wiki/wiki/Packets#packet-header) out. 
* Nodes are now able to connect to each other via TCP.
* Stabilized packet sending and encryption logic.